### PR TITLE
Feat/UI improvement

### DIFF
--- a/src/CO2_Controller/CO2Controller.cpp
+++ b/src/CO2_Controller/CO2Controller.cpp
@@ -210,6 +210,7 @@ void CO2Controller::controlTask(void* pvParameters)
                 // below max setpoint, exit emergency, let normal control task handle the rest (fan will be adjusted in next loop)
                 controller_state = IDLE;
                 Debug::println("CO2 level safe: %.2f ppm. Exiting EMERGENCY state.", CO2_value);
+                xEventGroupClearBits(self->event_group, CO2_WARNING);
             }
             break;
         }

--- a/src/Greenhouse_Monitor/GreenhouseMonitor.cpp
+++ b/src/Greenhouse_Monitor/GreenhouseMonitor.cpp
@@ -115,6 +115,14 @@ void GreenhouseMonitor::read_sensor_task() {
             ui.set_Relative_humidity(systemData.humidity);
             ui.set_fan_speed(systemData.fanSpeed);
             ui.set_CO2_level(systemData.co2Level);
+            auto bit = xEventGroupGetBits(monitor_event_group);
+            if (bit&CO2_WARNING) {
+                printf("warning");
+                ui.set_CO2_alarm(true);
+            }
+            else {
+                ui.set_CO2_alarm(false);
+            }
         }
     }
 
@@ -160,7 +168,7 @@ void GreenhouseMonitor::greenhouse_monitor_task() {
 
     while (1) {
         auto bit = xEventGroupWaitBits(monitor_event_group,
-            UI_SET_CO2 | NETWORK_SET_CO2| CO2_WARNING,
+            UI_SET_CO2 | NETWORK_SET_CO2,
             pdTRUE, pdFALSE, portMAX_DELAY);
         if (bit&UI_SET_CO2) {
             int set_point = ui.get_CO2_level();
@@ -179,9 +187,6 @@ void GreenhouseMonitor::greenhouse_monitor_task() {
             co2_controller.setCO2Setpoint(static_cast<float>(systemData.co2SetPoint));
             ui.set_CO2_level(systemData.co2SetPoint);
             eeprom.writeCO2Value(systemData.co2SetPoint);
-        }
-        if (bit&CO2_WARNING) {
-            printf("warning");
         }
     }
 

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -119,9 +119,9 @@ void UI_control::display_main(){
   EventBits_t bits = xEventGroupGetBits(event_group);
   sprintf(buff,"CO2:%d",co2_level);
   display->text(buff, 0, 0);
-  sprintf(buff,"Humidity: %.1f",Relative_humidity);
+  sprintf(buff,"Humidity:%.1f",Relative_humidity);
   display->text(buff, 0, 8);
-  sprintf(buff,"Temperature: %.1f",Temperature);
+  sprintf(buff,"Temp:%.1f",Temperature);
   display->text(buff, 0, 16);
   if((bits&CO2_WARNING) && fan_speed == 100){
     display->text("Fan on !!ALARM!!", 0, 24);
@@ -236,6 +236,7 @@ void UI_control::handle_set_co2_event(const gpioEvent &event) {
 }
 
 void UI_control::handle_network_scroll(const gpioEvent &event) {
+  strcpy(ssid, ssid_list[ssid_list_index]);
   if(event.type == gpioType::ROT_ENCODER){
     vTaskDelay(pdMS_TO_TICKS(500));
     EventBits_t bits = xEventGroupGetBits(event_group);

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -17,7 +17,6 @@
 #define UI_GET_NETWORK (1 << 1)
 #define UI_SSID_READY (1 << 2)
 #define UI_CONNECT_NETWORK (1 << 3)
-#define CO2_WARNING (1<<7)
 #define WIFI_CONNECTED (1 << 9)
 
 UI_control* UI_control::instance_ptr = nullptr;
@@ -93,7 +92,7 @@ void UI_control::init(){
 int UI_control::get_CO2_level(){ return co2SetPoint;}
 char* UI_control::get_ssid(){ return ssid;}
 char* UI_control::get_password(){ return password;}
-void UI_control::set_CO2_level(uint16_t new_level){ co2_level = new_level;needs_update=true; }
+void UI_control::set_CO2_level(int new_level){ co2_level = new_level;needs_update=true; }
 void UI_control::set_Relative_humidity(float new_humidity){ Relative_humidity = new_humidity; needs_update=true; }
 void UI_control::set_Temperature(float new_temperature){ Temperature = new_temperature; needs_update=true; }
 void UI_control::set_fan_speed(int new_status){ fan_speed= new_status; needs_update=true; }
@@ -114,26 +113,44 @@ void  UI_control::set_network_status(bool status) {
   needs_update=true;
 }
 
+void UI_control::set_CO2_alarm(bool is_Emergency) {
+  co2_alarm = is_Emergency;
+  needs_update=true;
+}
+
 void UI_control::display_main(){
   char buff[32];
-  EventBits_t bits = xEventGroupGetBits(event_group);
-  sprintf(buff,"CO2:%d",co2_level);
-  display->text(buff, 0, 0);
-  sprintf(buff,"Humidity:%.1f",Relative_humidity);
-  display->text(buff, 0, 8);
-  sprintf(buff,"Temp:%.1f",Temperature);
-  display->text(buff, 0, 16);
-  if((bits&CO2_WARNING) && fan_speed == 100){
-    display->text("Fan on !!ALARM!!", 0, 24);
+  sprintf(buff,"%dppm",co2_level);
+  display->text("CO2:" , 0, 0);
+  display->text(buff, 70, 0);
+  sprintf(buff,"%dppm" ,co2SetPoint);
+  display->text("Target:" , 0, 8);
+  display->text(buff, 70, 8);
+  sprintf(buff,"%.1f%%",Relative_humidity);
+  display->text("Rh:", 0, 16);
+  display->text(buff, 70, 16);
+  sprintf(buff,"%.1fC",Temperature);
+  display->text("Temp:", 0, 24);
+  display->text(buff, 70, 24);
+  if(co2_alarm){
+    display->rect(0,33,128,8,1,true);
+    display->text("Fan:", 0, 33,0);
+    display->text("!!ALARM!!", 40, 33,0);
   } else if (fan_speed > 0){
-    display->text("Fan on", 0, 24);
-  } else
-  if(connected_to_network) {
-    display->text("Network:Online", 0, 32);
-  } else {
-    display->text("Network:Offline", 0, 32);
+    display->text("Fan:", 0, 33);
+    display->text("ON", 70, 33);
+  } else{
+    display->text("Fan:", 0, 33);
+    display->text("OFF", 70, 33);
   }
-  display->text("Button for Menu", 0, 50);
+  display->text("Network:", 0, 42);
+  if(connected_to_network) {
+    display->text("Online", 70, 42);
+  } else {
+    display->text("Offline", 70, 42);
+  }
+  display->rect(0,54,128,8,1,true);
+  display->text("Button for Menu", 0, 54, 0);
 }
 
 void UI_control::display_menu(){
@@ -229,7 +246,7 @@ void UI_control::handle_set_co2_event(const gpioEvent &event) {
   if(event.type == gpioType::ROT_SWITCH){
     display_successfull_set_co2();
     vTaskDelay(pdMS_TO_TICKS(3000));
-    current_state = UIState::SETTING_MENU;
+    current_state = UIState::MAIN;
     xEventGroupSetBits(event_group, UI_SET_CO2);
     needs_update = true;
   }
@@ -328,13 +345,13 @@ void UI_control::run() {
   const uint32_t debounce_ms[5] = {50, 250, 250, 250, 250};
   EventBits_t bits = xEventGroupGetBits(event_group);
 
-
+  display->fill(0);
   display_main();
   display->show();
   needs_update=false;
 
   while(true){
-    if(xQueueReceive(input_queue, &event, portMAX_DELAY)==pdTRUE){
+    if(xQueueReceive(input_queue, &event, pdMS_TO_TICKS(50))==pdTRUE){
       int index = -1;
       switch(event.type) {
         case gpioType::ROT_ENCODER: index = 0; break;

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -56,12 +56,13 @@ public:
   char* get_ssid();
   char* get_password();
 
-  void set_CO2_level(uint16_t CO2_level);
+  void set_CO2_level(int CO2_level);
   void set_Relative_humidity(float Relative_humidity);
   void set_Temperature(float Temperature);
   void set_fan_speed(int Fan_speed);
   void set_ssid_list(const char* list[]);
   void set_network_status(bool status);
+  void set_CO2_alarm(bool is_Emergency);
 
   void display_main();
   void display_menu();
@@ -74,6 +75,7 @@ public:
   void handle_set_co2_event(const gpioEvent &event);
   void handle_network_scroll(const gpioEvent &event);
   void handle_network_manual(const gpioEvent &event, char *buffer);
+
 
   void run();
   static void runner(void *params);
@@ -93,6 +95,7 @@ private:
   float Relative_humidity=0.0;
   float Temperature=0.0;
   int fan_speed=0;
+  bool co2_alarm=false;
 
   //Network info
   char ssid[64];


### PR DESCRIPTION
This pull request refactors the CO2 alarm handling and display logic, improving how emergency CO2 conditions are communicated to the user interface. The main changes involve replacing the use of the `CO2_WARNING` event bit in UI logic with a new `co2_alarm` state in the `UI_control` class, updating the display to show clearer alarm and status information, and cleaning up event handling related to CO2 warnings.

**CO2 alarm handling and UI improvements:**

* Added a `co2_alarm` boolean state and a `set_CO2_alarm` method to `UI_control`, allowing the UI to directly reflect emergency CO2 conditions rather than relying on the `CO2_WARNING` event bit. (F34c9d22L95R95, [src/ui/ui.cppR116-R153](diffhunk://#diff-35d9167145f4a0bf945aa22a0c2bf4af3c01e95c978ced3af122e1e19812e1f3R116-R153))
* Updated the main display logic in `UI_control::display_main` to show a prominent alarm banner when `co2_alarm` is set, and improved layout for CO2, humidity, temperature, fan, and network status information.
* Modified the `GreenhouseMonitor` tasks to set and clear the CO2 alarm state in the UI based on the `CO2_WARNING` event bit, and removed redundant warning prints. [[1]](diffhunk://#diff-90558aa85fcb0e19379221461f7f28f1e117126329301f8490a1d1ff874b3da7R118-R125) [[2]](diffhunk://#diff-90558aa85fcb0e19379221461f7f28f1e117126329301f8490a1d1ff874b3da7L183-L185)
* Removed the definition of `CO2_WARNING` from the UI header, decoupling UI logic from event bit definitions.

**Event and state handling improvements:**

* Changed the event handling in `CO2Controller::controlTask` to clear the `CO2_WARNING` event bit when exiting emergency state, ensuring proper synchronization between control logic and UI alarm state.
* Updated the CO2 setpoint event handling to return to the main UI state after successful setpoint adjustment, improving user experience.
* Changed the CO2 level type in `UI_control` methods from `uint16_t` to `int` for consistency. [[1]](diffhunk://#diff-35d9167145f4a0bf945aa22a0c2bf4af3c01e95c978ced3af122e1e19812e1f3L96-R95) [[2]](diffhunk://#diff-7d888d30ff46fdaceade933ee228da73e9eb0454f9285563b7ca8ff5b098e905L59-R65)

These changes make the CO2 alarm system more robust, improve user feedback on the UI, and simplify the event-driven architecture.